### PR TITLE
Supports Apple Silicon

### DIFF
--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -285,7 +285,7 @@
       "steps" : [
         {
           "name" : "Download all artifacts",
-          "uses" : "actions/download-artifact@v3"
+          "uses" : "actions/download-artifact@v4"
         },
         {
           "name" : "Prepare artifacts for release",

--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -233,7 +233,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {
@@ -249,7 +249,10 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build"
+          "run" : "cmake -S . -B build",
+          "env" : {
+            "CMAKE_OSX_ARCHITECTURES":"x86_64;arm64"
+          }
         },
         {
           "name" : "Build project",


### PR DESCRIPTION
The Previous Plugin for MacOS is not build as Universal Binary,therefore cannot load this pluign without Rosetta 2.(like that)

----

<img width="785" alt="image" src="https://github.com/krkrsdl2/KAGParser/assets/58556570/25b53bf2-b07e-4ee7-8242-0dd85107dc41">

----

This change makes universal binary to able to load plugin without Rosetta 2.